### PR TITLE
Log but don't throw if agent isn't running

### DIFF
--- a/src/dagsterCloud.js
+++ b/src/dagsterCloud.js
@@ -20,6 +20,7 @@ const ADD_LOCATION_MUTATION = gql`
       }
       ... on PythonError {
         message
+        className
         stack
       }
     }
@@ -90,7 +91,11 @@ export class DagsterCloudClient {
     }
 
     if (result.__typename === "PythonError") {
-      throw new Error(result.message);
+      if (result.className === "dagster.core.errors.DagsterUserCodeUnreachableError" ) {
+        console.log(result.message);
+      } else {
+        throw new Error(result.message);
+      }
     }
 
     return result.locationName;


### PR DESCRIPTION
We're experimenting with a development flow that involves:

- Every PR deploying to the GitHub author's personal deployment (or even
  a branch-specific deployment)
- The developer (or reviewer) then optionally spinning up a Docker Agent
  locally to interact with the changes

With this workflow, it's expected that an agent often won't be running
when the CI/CD action runs. So instead of throwing on:

```
Error: dagster.core.errors.DagsterUserCodeUnreachableError:
Could not send request to agent since no agents have recently heartbeated
```

We'll log it instead.